### PR TITLE
備品一覧画面での所有者一覧から1つも持っていないownerを排除

### DIFF
--- a/src/components/Item/ItemPanel.vue
+++ b/src/components/Item/ItemPanel.vue
@@ -12,7 +12,7 @@
       </div>
       <div :class="$style.main">
         <div :class="$style.owners">
-          {{ item.owners.map(owner => `@${owner.user.name}`).join() }}
+          {{ item.owners.filter(owner => owner.count > 0).map(owner => `@${owner.user.name}`).join() }}
         </div>
         <div :class="$style.like" @click.prevent="toggleLike">
           <a-icon v-if="!isLiked" name="mdi:heart-outline" :size="20" />


### PR DESCRIPTION
1つも所有していないownerを表示から排除
このPRでItemDetailsの画面からは排除したが、備品/物品一覧の画面ではまだ残っていたため
https://github.com/traPtitech/booQ-UI/pull/1089